### PR TITLE
Новый режим парсинга

### DIFF
--- a/src/main/java/ru/naumen/perfhouse/plugins/nio/NioConstants.java
+++ b/src/main/java/ru/naumen/perfhouse/plugins/nio/NioConstants.java
@@ -1,0 +1,19 @@
+package ru.naumen.perfhouse.plugins.nio;
+
+import com.google.common.collect.Lists;
+import org.springframework.stereotype.Component;
+import ru.naumen.perfhouse.statdata.PluginConstants;
+
+import java.util.List;
+
+import static ru.naumen.perfhouse.statdata.Constants.TIME;
+
+@Component
+public class NioConstants implements PluginConstants {
+    public final String AVG_TIME = "avgTime";
+    public final String MAX_TIME = "maxTime";
+
+    public List<String> getProps() {
+        return Lists.newArrayList(TIME, AVG_TIME, MAX_TIME);
+    }
+}

--- a/src/main/java/ru/naumen/perfhouse/plugins/nio/NioController.java
+++ b/src/main/java/ru/naumen/perfhouse/plugins/nio/NioController.java
@@ -1,0 +1,52 @@
+package ru.naumen.perfhouse.plugins.nio;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+import ru.naumen.perfhouse.controllers.HistoryController;
+import ru.naumen.perfhouse.tabs.HistoryTab;
+
+import java.text.ParseException;
+
+@Controller
+@HistoryTab(name = "Parser data", path = "/nio")
+public class NioController extends HistoryController
+{
+    private static final String NIO_VIEW = "nio_history";
+
+    @Autowired
+    private NioConstants constants;
+
+    @RequestMapping(path = "/history/{client}/nio/{year}/{month}/{day}")
+    public ModelAndView getByDay(@PathVariable("client") String client,
+                                     @PathVariable(name = "year", required = false) int year,
+                                     @PathVariable(name = "month", required = false) int month,
+                                     @PathVariable(name = "day", required = false) int day) throws ParseException
+    {
+        return getDataAndViewByDate(client, constants, year, month, day, NIO_VIEW);
+    }
+
+    @RequestMapping(path = "/history/{client}/nio/{year}/{month}")
+    public ModelAndView getByMonth(@PathVariable("client") String client,
+                                       @PathVariable(name = "year", required = false) int year,
+                                       @PathVariable(name = "month", required = false) int month) throws ParseException
+    {
+        return getDataAndViewByDate(client, constants, year, month, 0, NIO_VIEW, true);
+    }
+
+    @RequestMapping(path = "/history/{client}/nio")
+    public ModelAndView getLast(@PathVariable("client") String client,
+                                       @RequestParam(name = "count", defaultValue = "864") int count) throws ParseException
+    {
+        return getDataAndView(client, constants, count, NIO_VIEW);
+    }
+
+    @RequestMapping(path = "/history/{client}/custom/nio")
+    public ModelAndView getCustom(@PathVariable("client") String client, @RequestParam("from") String from,
+                                      @RequestParam("to") String to, @RequestParam("maxResults") int count) throws ParseException {
+        return getDataAndViewCustom(client, constants, from, to, count, NIO_VIEW);
+    }
+}

--- a/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioData.java
+++ b/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioData.java
@@ -1,0 +1,35 @@
+package ru.naumen.perfhouse.plugins.nio.parser;
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import ru.naumen.perfhouse.parser.interfaces.DataSet;
+
+import static ru.naumen.perfhouse.parser.NumberUtils.getSafeDouble;
+import static ru.naumen.perfhouse.parser.NumberUtils.roundToTwoPlaces;
+
+/**
+ * Created by doki on 22.10.16.
+ */
+public class NioData implements DataSet
+{
+    private DescriptiveStatistics timeStat = new DescriptiveStatistics();
+
+    public void addValue(long time)
+    {
+        timeStat.addValue(time);
+    }
+
+    public boolean isNan()
+    {
+        return timeStat.getN() == 0;
+    }
+
+    public double getAvg()
+    {
+        return roundToTwoPlaces(getSafeDouble(timeStat.getMean()));
+    }
+
+    public double getMax()
+    {
+        return roundToTwoPlaces(getSafeDouble(timeStat.getMax()));
+    }
+}

--- a/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioDataParser.java
+++ b/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioDataParser.java
@@ -1,0 +1,29 @@
+package ru.naumen.perfhouse.plugins.nio.parser;
+
+import org.springframework.stereotype.Service;
+import ru.naumen.perfhouse.parser.ParsingMode;
+import ru.naumen.perfhouse.parser.interfaces.DataParser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by doki on 22.10.16.
+ */
+@Service
+@ParsingMode(name="nio")
+public class NioDataParser implements DataParser<NioData> {
+    private static final Pattern renderTimePattern = Pattern.compile(".*render time: (\\d+)");
+
+    @Override
+    public void parseLine(String line, NioData currentSet)
+    {
+        Matcher matcher = renderTimePattern.matcher(line);
+        if (!matcher.find())
+        {
+            return;
+        }
+
+        currentSet.addValue(Integer.parseInt(matcher.group(1)));
+    }
+}

--- a/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioParserFactory.java
+++ b/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioParserFactory.java
@@ -1,0 +1,19 @@
+package ru.naumen.perfhouse.plugins.nio.parser;
+
+import org.springframework.stereotype.Service;
+import ru.naumen.perfhouse.parser.interfaces.ParserFactory;
+import ru.naumen.perfhouse.parser.ParsingMode;
+
+@Service
+@ParsingMode(name="nio")
+public class NioParserFactory implements ParserFactory {
+    @Override
+    public NioData getDataSet() {
+        return new NioData();
+    }
+
+    @Override
+    public NioTimeParser getTimeParser(String logPath, String timeZone) {
+        return new NioTimeParser(timeZone);
+    }
+}

--- a/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioStoragePacker.java
+++ b/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioStoragePacker.java
@@ -1,0 +1,38 @@
+package ru.naumen.perfhouse.plugins.nio.parser;
+
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.naumen.perfhouse.parser.interfaces.StoragePacker;
+import ru.naumen.perfhouse.parser.ParsingMode;
+import ru.naumen.perfhouse.plugins.nio.NioConstants;
+import ru.naumen.perfhouse.statdata.Constants;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@ParsingMode(name="nio")
+public class NioStoragePacker implements StoragePacker<NioData> {
+    private NioConstants constants;
+
+    @Autowired
+    public NioStoragePacker(NioConstants constants) {
+        this.constants = constants;
+    }
+
+    public void store(BatchPoints points, String currentDb, long currentKey,
+                      NioData currentSet, boolean printLog) {
+
+        if (!currentSet.isNan())
+        {
+            Point point = Point.measurement(Constants.MEASUREMENT_NAME)
+                    .time(currentKey, TimeUnit.MILLISECONDS)
+                    .addField(constants.AVG_TIME, currentSet.getAvg())
+                    .addField(constants.MAX_TIME, currentSet.getMax())
+                    .build();
+
+            points.getPoints().add(point);
+        }
+    }
+}

--- a/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioTimeParser.java
+++ b/src/main/java/ru/naumen/perfhouse/plugins/nio/parser/NioTimeParser.java
@@ -1,0 +1,45 @@
+package ru.naumen.perfhouse.plugins.nio.parser;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+import ru.naumen.perfhouse.parser.interfaces.TimeParser;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by doki on 22.10.16.
+ */
+@Service
+@Scope("request")
+public class NioTimeParser implements TimeParser
+{
+    private static final Pattern TIME_PATTERN = Pattern.compile(
+            "^\\d{9} (\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3})");
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat(
+            "yyyy-MM-dd HH:mm:ss,SSS", new Locale("ru", "RU"));
+
+    public NioTimeParser(String timeZone)
+    {
+        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone(timeZone));
+    }
+
+    @Override
+    public long parseTime(String line) throws ParseException
+    {
+        Matcher matcher = TIME_PATTERN.matcher(line);
+
+        if (matcher.find())
+        {
+            String timeString = matcher.group(1);
+
+            return DATE_FORMAT.parse(timeString).getTime();
+        }
+
+        return 0L;
+    }
+}

--- a/src/main/java/ru/naumen/perfhouse/tabs/HistoryTabs.java
+++ b/src/main/java/ru/naumen/perfhouse/tabs/HistoryTabs.java
@@ -1,34 +1,37 @@
 package ru.naumen.perfhouse.tabs;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Service
-public class HistoryTabs {
+public class HistoryTabs implements BeanPostProcessor {
     @Autowired
     private ListableBeanFactory beanFactory;
 
     private Map<String, String> tabs = new HashMap<>();
 
-    private synchronized Map<String, String> calculateTabs() {
-        if (tabs.size() == 0) {
-            Map<String, Object> parserBeans = beanFactory.getBeansWithAnnotation(HistoryTab.class);
-
-            for (Object parserBean : parserBeans.values()) {
-                HistoryTab annotation = parserBean.getClass().getAnnotation(HistoryTab.class);
-
-                tabs.put(annotation.name(), annotation.path());
-            }
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        HistoryTab annotation = bean.getClass().getAnnotation(HistoryTab.class);
+        if (annotation != null) {
+            tabs.put(annotation.name(), annotation.path());
         }
 
-        return tabs;
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
     }
 
     public Map<String, String> getTabs() {
-        return calculateTabs();
+        return tabs;
     }
 }

--- a/src/main/webapp/WEB-INF/jsp/nio_history.jsp
+++ b/src/main/webapp/WEB-INF/jsp/nio_history.jsp
@@ -1,0 +1,250 @@
+<%@page import="ru.naumen.perfhouse.statdata.Constants"%>
+<%@ page import="ru.naumen.perfhouse.plugins.nio.NioConstants" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.Date" %>
+<%@ page import="org.influxdb.dto.QueryResult.Series" %>
+
+<html>
+
+<head>
+    <title>SD40 Performance indicator</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+    <script src="/js/jquery-3.1.1.min.js"></script>
+
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css"
+                integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi"
+                crossorigin="anonymous"/>
+    	<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js"
+                integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB"
+                crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js"
+            integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK"
+            crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="/css/style.css"/>
+    <style>
+        .col-xs-40 {
+        	width: 34%;
+        }
+        .col-xs-10 {
+        	width: 11%;
+        }
+    }
+    </style>
+    <script>
+            $(document).ready(function() {
+                var path = location.pathname + location.search;
+                $('.nav-item a').each(function(index, elem) {
+                     var jElem = $(elem);
+                     if (jElem.attr('href') == path) {
+                        jElem.removeClass("btn btn-outline-primary").addClass("nav-link active");
+                     }
+                });
+            })
+        </script>
+</head>
+
+<body>
+
+<script src="http://code.highcharts.com/highcharts.js"></script>
+<%
+    NioConstants pluginConstants = (NioConstants)request.getAttribute("constants");
+
+    Number times[] = (Number[])request.getAttribute(Constants.TIME);
+    Number avgTime[]=  (Number[])request.getAttribute(pluginConstants.AVG_TIME);
+    Number maxTime[]=  (Number[])request.getAttribute(pluginConstants.MAX_TIME);
+    
+  //Prepare links
+  	String path="";
+  	String custom = "";
+  	if(request.getAttribute("custom") == null){
+  	Object year = request.getAttribute("year");
+  	Object month = request.getAttribute("month");
+  	Object day = request.getAttribute("day");
+      
+      String countParam = (String)request.getParameter("count");
+      
+  	String params = "";
+  	String datePath = "";
+
+  	StringBuilder sb = new StringBuilder();
+
+
+  	if(countParam != null){
+      	params = sb.append("?count=").append(countParam).toString();
+  	}else{
+      	sb.append('/').append(year).append('/').append(month);
+      	if(!day.toString().equals("0")){
+          	sb.append('/').append(day);
+      	}
+      	datePath = sb.toString();
+  	}
+  	path = datePath + params;
+  	}
+  	else{
+  	    custom = "/custom";
+  	    Object from = request.getAttribute("from");
+  	  	Object to = request.getAttribute("to");
+  	  	Object maxResults = request.getAttribute("maxResults");
+  	  	
+  	  	StringBuilder sb = new StringBuilder();
+  	  	path = sb.append("?from=").append(from).append("&to=").append(to).append("&maxResults=").append(maxResults).toString();
+  	}
+      
+%>
+
+<div class="container">
+	<br>
+    <h1>Performance data for "${client}"</h1>
+    <h3><a class="btn btn-success btn-lg" href="/">Client list</a></h3>
+    <h4 id="date_range"></h4>
+    <p>
+        Feel free to hide/show specific data by clicking on chart's legend
+    </p>
+    <ul class="nav nav-pills">
+		<%  Map<String, String> tabs = (Map<String, String>)request.getAttribute("tabs");
+                for (String name : tabs.keySet()) {
+            %>
+                <li class="nav-item"><a class="btn btn-outline-primary" href="/history/${client}<%=custom %><%=tabs.get(name) %><%=path%>"><%=name %></a></li>
+            <%
+                }
+            %>
+	</ul>
+</div>
+
+<div class="container">
+<div id="cpu-chart-container" style="height: 600px"></div>
+<div >
+	<table class="table table-fixed header-fixed">
+        <thead class="thead-inverse">
+            <th class="col-xs-40">Time</th>
+            <th class="col-xs-10">Avg parser time</th>
+            <th class="col-xs-10">Max parser time</th>
+        </thead>
+        <tbody>
+            <% for(int i=0;i<times.length;i++) {%>
+                <tr class="row">
+                    <td class="col-xs-40" style="text-align:center;">
+                       <%= new java.util.Date(times[i].longValue()).toString() %>
+                    </td>
+                    <td class="col-xs-10" >
+                        <%= avgTime[i] %>
+                    </td>
+                    <td class="col-xs-10">
+                        <%= maxTime[i] %>
+                    </td>
+                </tr>
+            <% } %>
+        </tbody>
+    </table>
+</div>
+
+</div>
+<script type="text/javascript">
+var times = [];
+var avgTime = [];
+var maxTime = [];
+
+<% for(int i=0;i<times.length;i++) {%>
+    times.push((<%=times[i]%>));
+    avgTime.push([new Date(<%= times[i] %>), <%= avgTime[i] %>]);
+    maxTime.push([new Date(<%= times[i] %>), <%= maxTime[i] %>]);
+<% } %>
+
+document.getElementById('date_range').innerHTML += 'From: '+new Date(times[<%=times.length%>-1])+'<br/>To:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' +new Date(times[0])
+
+if(localStorage.getItem('avgTime')==null){
+    localStorage.setItem('avgTime', 'true');
+}
+if(localStorage.getItem('maxTime')==null){
+    localStorage.setItem('maxTime', 'true');
+}
+
+var avgTimeVisible = localStorage.getItem('avgTime')==='true';
+var maxTimeVisible = localStorage.getItem('maxTime')==='true';
+
+Highcharts.setOptions({
+	global: {
+		useUTC: false
+	}
+});
+
+var myChart = Highcharts.chart('cpu-chart-container', {
+        chart: {
+                zoomType: 'x,y'
+            },
+
+        title: {
+            text: 'Parser data'
+        },
+
+        tooltip: {
+            formatter: function() {
+                            var index = this.point.index;
+                            var date =  new Date(times[index]);
+                            return Highcharts.dateFormat('%a %d %b %H:%M:%S', date)
+                            + '<br/> <b>'+this.series.name+'</b> '+ this.y + '<br/>'
+                        }
+        },
+
+        xAxis: {
+            labels:{
+                formatter:function(obj){
+//                        var index = this.point.index;
+//                        var date =  new Date(times[index]);
+                        return Highcharts.dateFormat('%a %d %b %H:%M:%S', new Date(times[this.value]));
+                    }
+                },
+                reversed: true
+        },
+
+        yAxis: {
+            title: {
+                text: 'Parser time'
+            },
+            plotLines: [{
+                value: 0,
+                width: 1,
+                color: '#808080'
+            }]
+        },
+        plotOptions: {
+            line: {
+                marker: {
+                    enabled: false
+                },
+                events: {
+                    legendItemClick: function(event) {
+                        var series = this.yAxis.series;
+                        seriesLen = series.length;
+
+                        if(event.target.index==0){
+                            localStorage.setItem('avgTime', !series[0].visible);
+                        }
+                        if(event.target.index==1){
+                            localStorage.setItem('maxTine', !series[1].visible);
+                        }
+                    }
+                }
+            }
+        },
+        series: [{
+            name: 'Average Time',
+            data: avgTime,
+            visible: avgTimeVisible,
+            turboThreshold: 10000
+        }, {
+            name: 'Max Time',
+            data: maxTime,
+            visible: maxTimeVisible,
+            turboThreshold: 10000
+        }]
+});
+
+</script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Я добавил парсер для нового типа логов, но не особо понял какую конкретно информацию надо выводить в интерфейсе.
По сравнению с первой версией программы, добавлять поддержку новых типов логов стало ощутимо проще :)

![image](https://user-images.githubusercontent.com/10204278/34178636-b84b2cbe-e529-11e7-8dc1-bbed397eaf9b.png)

## Задание

Добавить новый режим парсинга (всю функциональность: парсинг-хранение-отображение) для логов следующего вида:

102725313 2017-12-13 03:48:56,048 [http-nio-8443-exec-83 operator1 fs000080000m0jaoh10o2ito00] DEBUG AdvFormEngine - session: fs000080000m0jaoh10o2ito00 render time: 18

На данный момент нас интересует только дата: 2017-12-13 03:48:56,048 и время отрисовки страницы (render time) - 18 миллисекунд.

Нужно вывести статистику наподобие ActionDone.

@ykalemi